### PR TITLE
Fix node audit warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.3] - Remove unused dependency
+
+#### Changed
+- Removed unused `tinyify` dependency
+
 ## [1.0.2] - Remove Testing Code & Add Ignore Modules option
 
 #### Added:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "homepage": "https://github.com/shbatm/MMM-Logging#readme",
   "dependencies": {
-    "tinyify": "^3.1.0",
     "tracer": "github:shbatm/tracer"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/shbatm/MMM-Logging#readme",
   "dependencies": {
-    "tinyify": "^4.0.0",
+    "tinyify": "^3.1.0",
     "tracer": "github:shbatm/tracer"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/shbatm/MMM-Logging#readme",
   "dependencies": {
-    "tinyify": "^2.5.0",
+    "tinyify": "^4.0.0",
     "tracer": "github:shbatm/tracer"
   }
 }


### PR DESCRIPTION
Node believes that tinyify v2.5 is a "high" severity vulnerability.  This PR updates package.json to call for v3.1, which seems to work.

Note that node still reports 2 "high" vulnerabilities:

```sh
# npm audit report

terser  <4.8.1
Severity: high
Terser insecure use of regular expressions leads to ReDoS - https://github.com/advisories/GHSA-4wf5-vphf-c2xc
fix available via `npm audit fix`
node_modules/uglifyify/node_modules/terser
  uglifyify  >=5.0.1
  Depends on vulnerable versions of terser
  node_modules/uglifyify

2 high severity vulnerabilities

To address all issues, run:
  npm audit fix
```